### PR TITLE
Remove concept of transient dependencies

### DIFF
--- a/SampleProjects/ConsoleApp1/ConsoleApp1.csproj
+++ b/SampleProjects/ConsoleApp1/ConsoleApp1.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>netcoreapp1.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <DotNetCliToolReference Include="dotnet-retire" Version="1.0.4-beta002" />
+        <DotNetCliToolReference Include="dotnet-retire" Version="1.0.3" />
     </ItemGroup>
     <ItemGroup>
       <PackageReference Include="Dapper" Version="1.50.2" />

--- a/SampleProjects/ConsoleApp1/ConsoleApp1.csproj
+++ b/SampleProjects/ConsoleApp1/ConsoleApp1.csproj
@@ -4,10 +4,10 @@
         <TargetFramework>netcoreapp1.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <DotNetCliToolReference Include="dotnet-retire" Version="1.0.3" />
+        <DotNetCliToolReference Include="dotnet-retire" Version="1.0.4" />
     </ItemGroup>
     <ItemGroup>
       <PackageReference Include="Dapper" Version="1.50.2" />
-      <PackageReference Include="System.Net.Security" Version="4.3.1" />
+      <PackageReference Include="System.Net.Security" Version="4.3.0" />
     </ItemGroup>
 </Project>

--- a/SampleProjects/ConsoleApp1/ConsoleApp1.csproj
+++ b/SampleProjects/ConsoleApp1/ConsoleApp1.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>netcoreapp1.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <DotNetCliToolReference Include="dotnet-retire" Version="1.0.3" />
+        <DotNetCliToolReference Include="dotnet-retire" Version="1.0.4-beta002" />
     </ItemGroup>
     <ItemGroup>
       <PackageReference Include="Dapper" Version="1.50.2" />

--- a/SampleProjects/ConsoleApp1/ConsoleApp1.csproj
+++ b/SampleProjects/ConsoleApp1/ConsoleApp1.csproj
@@ -6,4 +6,8 @@
     <ItemGroup>
         <DotNetCliToolReference Include="dotnet-retire" Version="1.0.3" />
     </ItemGroup>
+    <ItemGroup>
+      <PackageReference Include="Dapper" Version="1.50.2" />
+      <PackageReference Include="System.Net.Security" Version="4.3.1" />
+    </ItemGroup>
 </Project>

--- a/Tests/NugetReferenceServiceTests.cs
+++ b/Tests/NugetReferenceServiceTests.cs
@@ -43,6 +43,20 @@ namespace Tests
             Assert.Equal("4.3.0", references.First().Dependencies.Last().Version);
         }
 
+        [Fact]
+        public void GetVulnerableDapperButWithManuallyUpdateSystemNetSecurity()
+        {
+            var references = NugetReferenceService("SingleTarget.ManuallyFixedUpgrade").GetNugetReferences();
+
+            Assert.Equal(2, references.Count());
+            Assert.Equal("Dapper", references.First().Id);
+            Assert.Equal("1.50.2", references.First().Version);
+            Assert.Equal(18, references.First().Dependencies.Count);
+
+
+            Assert.Equal("System.Net.Security", references.Last().Id);
+            Assert.Equal("4.3.1", references.Last().Version);
+        }
     }
 
     public class MockFileService : IFileService

--- a/Tests/NugetReferenceServiceTests.cs
+++ b/Tests/NugetReferenceServiceTests.cs
@@ -46,16 +46,19 @@ namespace Tests
         [Fact]
         public void GetVulnerableDapperButWithManuallyUpdateSystemNetSecurity()
         {
-            var references = NugetReferenceService("SingleTarget.ManuallyFixedUpgrade").GetNugetReferences();
+            var references = NugetReferenceService("SingleTarget.ManuallyFixedUpgrade").GetNugetReferences().ToArray();
 
-            Assert.Equal(2, references.Count());
-            Assert.Equal("Dapper", references.First().Id);
-            Assert.Equal("1.50.2", references.First().Version);
-            Assert.Equal(18, references.First().Dependencies.Count);
+            Assert.Equal(3, references.Count());
 
+            Assert.Equal("Dapper", references[0].Id);
+            Assert.Equal("1.50.2", references[0].Version);
+            Assert.Equal(18, references[0].Dependencies.Count);
 
-            Assert.Equal("System.Net.Security", references.Last().Id);
-            Assert.Equal("4.3.1", references.Last().Version);
+            Assert.Equal("System.Data.SqlClient", references[1].Id);
+            Assert.Equal("4.1.0", references[1].Version);
+
+            Assert.Equal("System.Net.Security", references[2].Id);
+            Assert.Equal("4.3.1", references[2].Version);
         }
     }
 

--- a/Tests/SingleTarget.ManuallyFixedUpgrade.project.assets.json
+++ b/Tests/SingleTarget.ManuallyFixedUpgrade.project.assets.json
@@ -32,6 +32,62 @@
             }
         },
 
+      "System.Data.SqlClient/4.1.0": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.Win32.Primitives": "4.0.1",
+          "System.Collections": "4.0.11",
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Data.Common": "4.1.0",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.DiagnosticSource": "4.0.0",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.IO.Pipes": "4.0.0",
+          "System.Linq": "4.1.0",
+          "System.Net.NameResolution": "4.0.0",
+          "System.Net.Primitives": "4.0.11",
+          "System.Net.Security": "4.0.0",
+          "System.Net.Sockets": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.1.0",
+          "System.Security.Principal": "4.0.1",
+          "System.Security.Principal.Windows": "4.0.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.CodePages": "4.0.1",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Thread": "4.0.0",
+          "System.Threading.ThreadPool": "4.0.10",
+          "System.Threading.Timer": "4.0.1",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "runtime.native.System.Data.SqlClient.sni": "4.0.0"
+        },
+        "compile": {
+          "ref/netstandard1.3/System.Data.SqlClient.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/unix/lib/netstandard1.3/System.Data.SqlClient.dll": {
+            "assetType": "runtime",
+            "rid": "unix"
+          },
+          "runtimes/win/lib/netstandard1.3/System.Data.SqlClient.dll": {
+            "assetType": "runtime",
+            "rid": "win"
+          }
+        }
+      },
+
         "System.Net.Security/4.3.1": {
             "type": "package",
             "dependencies": {

--- a/Tests/SingleTarget.ManuallyFixedUpgrade.project.assets.json
+++ b/Tests/SingleTarget.ManuallyFixedUpgrade.project.assets.json
@@ -1,0 +1,83 @@
+﻿{
+  "version": 2,
+  "targets": {
+    ".NETCoreApp,Version=v1.0": {
+        "Dapper/1.50.2": {
+            "type": "package",
+            "dependencies": {
+                "System.Collections": "4.0.11",
+                "System.Collections.Concurrent": "4.0.12",
+                "System.Collections.NonGeneric": "4.0.1",
+                "System.Data.SqlClient": "4.1.0",
+                "System.Dynamic.Runtime": "4.0.11",
+                "System.Linq": "4.1.0",
+                "System.Reflection": "4.1.0",
+                "System.Reflection.Emit": "4.0.1",
+                "System.Reflection.Emit.Lightweight": "4.0.1",
+                "System.Reflection.Extensions": "4.0.1",
+                "System.Reflection.TypeExtensions": "4.1.0",
+                "System.Runtime": "4.1.0",
+                "System.Runtime.Extensions": "4.1.0",
+                "System.Runtime.InteropServices": "4.1.0",
+                "System.Text.RegularExpressions": "4.1.0",
+                "System.Threading": "4.0.11",
+                "System.Xml.XDocument": "4.0.11",
+                "System.Xml.XmlDocument": "4.0.1"
+            },
+            "compile": {
+                "lib/netstandard1.3/Dapper.dll": {}
+            },
+            "runtime": {
+                "lib/netstandard1.3/Dapper.dll": {}
+            }
+        },
+
+        "System.Net.Security/4.3.1": {
+            "type": "package",
+            "dependencies": {
+                "Microsoft.NETCore.Platforms": "1.1.0",
+                "Microsoft.Win32.Primitives": "4.3.0",
+                "System.Collections": "4.3.0",
+                "System.Collections.Concurrent": "4.3.0",
+                "System.Diagnostics.Tracing": "4.3.0",
+                "System.Globalization": "4.3.0",
+                "System.Globalization.Extensions": "4.3.0",
+                "System.IO": "4.3.0",
+                "System.Net.Primitives": "4.3.0",
+                "System.Resources.ResourceManager": "4.3.0",
+                "System.Runtime": "4.3.0",
+                "System.Runtime.Extensions": "4.3.0",
+                "System.Runtime.Handles": "4.3.0",
+                "System.Runtime.InteropServices": "4.3.0",
+                "System.Security.Claims": "4.3.0",
+                "System.Security.Cryptography.Algorithms": "4.3.0",
+                "System.Security.Cryptography.Encoding": "4.3.0",
+                "System.Security.Cryptography.OpenSsl": "4.3.0",
+                "System.Security.Cryptography.Primitives": "4.3.0",
+                "System.Security.Cryptography.X509Certificates": "4.3.0",
+                "System.Security.Principal": "4.3.0",
+                "System.Text.Encoding": "4.3.0",
+                "System.Threading": "4.3.0",
+                "System.Threading.Tasks": "4.3.0",
+                "System.Threading.ThreadPool": "4.3.0",
+                "runtime.native.System": "4.3.0",
+                "runtime.native.System.Net.Security": "4.3.0",
+                "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+            },
+            "compile": {
+                "ref/netstandard1.3/System.Net.Security.dll": {}
+            },
+            "runtimeTargets": {
+                "runtimes/unix/lib/netstandard1.6/System.Net.Security.dll": {
+                    "assetType": "runtime",
+                    "rid": "unix"
+                },
+                "runtimes/win/lib/netstandard1.3/System.Net.Security.dll": {
+                    "assetType": "runtime",
+                    "rid": "win"
+                }
+            }
+        }
+    }
+  }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -20,6 +20,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="SingleTarget.ManuallyFixedUpgrade.project.assets.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="SingleTarget-MultipleDependencies.project.assets.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/Tests/UsageFinderTests.cs
+++ b/Tests/UsageFinderTests.cs
@@ -31,7 +31,7 @@ namespace Tests
         }
 
         [Fact]
-        public void TransientDependencyIsUsage()
+        public void TransientDependencyWhenOverriddenWithDirectReferenceIsNotVulnerableUsage()
         {
             var assets = new List<NugetReference>
             {
@@ -47,6 +47,11 @@ namespace Tests
                             Version = "1.0.0"
                         }
                     }
+                },
+                new NugetReference
+                {
+                    Id = "SomePackageId",
+                    Version = "2.0.0"
                 }
             };
 
@@ -57,8 +62,7 @@ namespace Tests
             }};
 
             var usages = UsagesFinder.FindUsagesOf(assets, packages);
-            Assert.Equal(1, usages.Count());
-            Assert.True(usages.First() is TransientUsage);
+            Assert.Equal(0, usages.Count());
         }
     }
 }

--- a/dotnet-retire/Models/TransientUsage.cs
+++ b/dotnet-retire/Models/TransientUsage.cs
@@ -1,7 +1,0 @@
-namespace dotnet_retire
-{
-    public class TransientUsage : Usage
-    {
-        public NugetReference ParentNugetReference { get; set; }
-    }
-}

--- a/dotnet-retire/Program.cs
+++ b/dotnet-retire/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -14,12 +15,18 @@ namespace dotnet_retire
 
         public Program()
         {
-            var builder = new ConfigurationBuilder().AddJsonFile("appsettings.json");
+            // var builder = new ConfigurationBuilder().AddJsonFile("appsettings.json");
+            var builder = new ConfigurationBuilder();
             Configuration = builder.Build();
 
-            var options = new RetireServiceOptions();
-            Configuration.GetSection("RetireServiceOptions").Bind(options);
-            
+            var options = new RetireServiceOptions
+            {
+                RootUrl =  "https://raw.githubusercontent.com/RetireNet/Packages/master/index.json"
+            };
+
+            // var options = new RetireServiceOptions();
+            //Configuration.GetSection("RetireServiceOptions").Bind(options);
+
             Services = new ServiceCollection()
                 .AddLogging()
                 .AddOptions()

--- a/dotnet-retire/Services/RetireLogger.cs
+++ b/dotnet-retire/Services/RetireLogger.cs
@@ -48,14 +48,7 @@ namespace dotnet_retire
             {
                 foreach (var usage in usages)
                 {
-                    if (usage is TransientUsage tUsage)
-                    {
-                        _logger.LogInformation($"Found transient reference of {usage.NugetReference} via {tUsage.ParentNugetReference}".Red());
-                    }
-                    else
-                    {
-                        _logger.LogInformation($"Found direct reference to {usage.NugetReference}".Red());
-                    }
+                    _logger.LogError($"Found direct reference to {usage.NugetReference}".Red());
                 }
             }
             else

--- a/dotnet-retire/Services/UsagesFinder.cs
+++ b/dotnet-retire/Services/UsagesFinder.cs
@@ -21,20 +21,6 @@ namespace dotnet_retire
                         Package = directPackage
                     });
                 }
-
-                foreach (var transientAsset in asset.Dependencies)
-                {
-                    var transientPackage = knownVulnerables.FirstOrDefault(k => k.Id == transientAsset.Id && k.Affected == transientAsset.Version);
-                    if (transientPackage != null)
-                    {
-                        usages.Add(new TransientUsage
-                        {
-                            ParentNugetReference = asset,
-                            NugetReference = transientAsset,
-                            Package = transientPackage
-                        });
-                    }
-                }
             }
 
             return usages;

--- a/dotnet-retire/dotnet-retire.csproj
+++ b/dotnet-retire/dotnet-retire.csproj
@@ -17,6 +17,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/RetireNet/images/master/nuget/dotnet-retire/icon.512x512.png</PackageIconUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReleaseNotes>
+     * Remove reporting on transient vulnerabilities.
      * Bugfix: Change to in-mem appSettings, as dotnet tools don't have access to NuGet content folder the same way as regular NuGets when they're run (path issues).
     </PackageReleaseNotes>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/dotnet-retire/dotnet-retire.csproj
+++ b/dotnet-retire/dotnet-retire.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <PackageId>dotnet-retire</PackageId>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <Authors>John Korsnes</Authors>
     <Description>
         A tool to check dependencies for versions with known vulnerabilities.
@@ -17,7 +17,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/RetireNet/images/master/nuget/dotnet-retire/icon.512x512.png</PackageIconUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReleaseNotes>
-     * Added support for project.json (preview tooling and project system)
+     * Bugfix: Change to in-mem appSettings, as dotnet tools don't have access to NuGet content folder the same way as regular NuGets when they're run (path issues).
     </PackageReleaseNotes>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/publish.cmd
+++ b/publish.cmd
@@ -1,1 +1,1 @@
-nuget push ./deploy/dotnet-retire.1.0.3.nupkg -Source https://www.nuget.org/api/v2/package -ApiKey %nugetorgapikey%
+nuget push ./deploy/dotnet-retire.1.0.4.nupkg -Source https://www.nuget.org/api/v2/package -ApiKey %nugetorgapikey%


### PR DESCRIPTION
They're all flattened when it comes to project.assets.json.

+ Bugfix re dotnet tools not able to read appsettings.json using Microsoft.Configuration.Json.