### PR TITLE
Appends matching on version

### DIFF
--- a/Tests/UsageFinderTests.cs
+++ b/Tests/UsageFinderTests.cs
@@ -86,7 +86,7 @@ namespace Tests
                 new NugetReference
                 {
                     Id = "B",
-                    Version = "2.0.0",
+                    Version = "3.0.0",
                     Dependencies = new List<NugetReference>
                     {
                         new NugetReference
@@ -111,8 +111,11 @@ namespace Tests
 
             var usages = UsagesFinder.FindUsagesOf(assets, packages);
             Assert.Equal(2, usages.Count);
-            Assert.Equal(1, usages.Count(u => u.OuterMostId == "A"));
-            Assert.Equal(1, usages.Count(u => u.OuterMostId == "B"));
+            Assert.Equal(1, usages.Count(u => u.OuterMostPackage.Id == "A"));
+            Assert.Equal(1, usages.Count(u => u.OuterMostPackage.Version == "2.0.0"));
+
+            Assert.Equal(1, usages.Count(u => u.OuterMostPackage.Id == "B"));
+            Assert.Equal(1, usages.Count(u => u.OuterMostPackage.Version == "3.0.0"));
         }
 
         [Fact]
@@ -162,7 +165,8 @@ namespace Tests
             var usages = UsagesFinder.FindUsagesOf(assets, packages);
             Assert.Single(usages);
             var usage = usages.Single();
-            Assert.Equal("A", usage.OuterMostId);
+            Assert.Equal("A", usage.OuterMostPackage.Id);
+            Assert.Equal("2.0.0", usage.OuterMostPackage.Version);
             Assert.True(usage.ReadPath().Contains("A") && usage.ReadPath().Contains("B"));
         }
     }

--- a/build.cake
+++ b/build.cake
@@ -3,7 +3,7 @@ var configuration = Argument("configuration", "Release");
 var projName = "dotnet-retire";
 var proj = $"./{projName}/{projName}.csproj";
 
-var version = "2.2.1";
+var version = "2.2.2";
 var outputDir = "./output";
 
 Task("Build")

--- a/dotnet-retire/Models/Usage.cs
+++ b/dotnet-retire/Models/Usage.cs
@@ -20,7 +20,8 @@ namespace dotnet_retire
             _referenceDepth.Add(asset);
         }
 
-        public string OuterMostId => _referenceDepth[_referenceDepth.Count - 1].Id;
+        public NugetReference OuterMostPackage => _referenceDepth[_referenceDepth.Count - 1];
+
         public bool IsDirect => _referenceDepth.Count == 1;
 
         public Usage Copy()

--- a/dotnet-retire/Services/UsagesFinder.cs
+++ b/dotnet-retire/Services/UsagesFinder.cs
@@ -30,7 +30,7 @@ namespace dotnet_retire
 
         private static IEnumerable<Usage> FindPathsTo(Usage usage, List<NugetReference> assets)
         {
-            var allWithThisChild = assets.Where(d => d.Dependencies.Any(c => c.Id == usage.OuterMostId)).ToList();
+            var allWithThisChild = assets.Where(d => d.Dependencies.Any(c => c.Id == usage.OuterMostPackage.Id && c.Version == usage.OuterMostPackage.Version)).ToList();
             if (allWithThisChild.Count == 0)
                 yield return usage;
             else


### PR DESCRIPTION
Transient dependencies were matching on `id` only missing `version`.