### PR TITLE
Bugfix: better handling when running in a sln directory

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -3,7 +3,7 @@ var configuration = Argument("configuration", "Release");
 var projName = "dotnet-retire";
 var proj = $"./{projName}/{projName}.csproj";
 
-var version = "2.3.0";
+var version = "2.3.1";
 var outputDir = "./output";
 
 Task("Build")

--- a/dotnet-retire/Services/RetireLogger.cs
+++ b/dotnet-retire/Services/RetireLogger.cs
@@ -48,7 +48,16 @@ namespace dotnet_retire
                 return;
             }
 
-            var nugetReferences = _nugetreferenceservice.GetNugetReferences().ToList();
+            List<NugetReference> nugetReferences;
+            try
+            {
+                nugetReferences = _nugetreferenceservice.GetNugetReferences().ToList();
+            }
+            catch (NoAssetsFoundException)
+            {
+                _logger.LogError("No assets found. Are you running the tool from a folder missing a csproj?");
+                return;
+            }
 
             _logger.LogDebug($"Found in total {nugetReferences.Count} references of NuGets (direct & transient)");
 


### PR DESCRIPTION
`dotnet restore` returns success when running in a sln level, but `dotnet retire`currently does not handle running from other workingDirs than where a csproj resides. This fix catches this scenario by exiting with a better error msg.