### PR TITLE
Move dependency graphs behind loglevel=debug

### DIFF
--- a/Linux.Vulnerable.Dockerfile
+++ b/Linux.Vulnerable.Dockerfile
@@ -18,4 +18,5 @@ ENV PATH="/root/.dotnet/tools:${PATH}"
 
 RUN dotnet tool list -g
 
+RUN dotnet retire loglevel=debug
 RUN dotnet retire

--- a/Windows.Vulnerable.Dockerfile
+++ b/Windows.Vulnerable.Dockerfile
@@ -17,4 +17,5 @@ RUN dotnet tool install -g dotnet-retire --add-source ../deploy --version=999.0.
 
 RUN dotnet tool list -g
 
+RUN dotnet retire loglevel=debug
 RUN dotnet retire

--- a/build.cake
+++ b/build.cake
@@ -3,7 +3,7 @@ var configuration = Argument("configuration", "Release");
 var projName = "dotnet-retire";
 var proj = $"./{projName}/{projName}.csproj";
 
-var version = "2.3.1";
+var version = "2.3.2";
 var outputDir = "./output";
 
 Task("Build")

--- a/dotnet-retire/Services/RetireLogger.cs
+++ b/dotnet-retire/Services/RetireLogger.cs
@@ -73,10 +73,13 @@ namespace dotnet_retire
                 {
                     errorLog += $"\n\n* {group.Key}".Red();
 
-                    foreach (var usage in group)
+                    if (_logger.IsEnabled(LogLevel.Debug))
                     {
-                        if(!usage.IsDirect)
-                            errorLog += $"\n{usage.ReadPath()}";
+                        foreach (var usage in group)
+                        {
+                            if(!usage.IsDirect)
+                                errorLog += $"\n{usage.ReadPath()}";
+                        }
                     }
                 }
 


### PR DESCRIPTION
Be less verbose by default. Enable it on demand.