### PR TITLE
Fix for Windows builds on AppVeyor

### DIFF
--- a/Windows.Dockerfile
+++ b/Windows.Dockerfile
@@ -1,9 +1,13 @@
-FROM microsoft/dotnet:2.1-sdk
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1
+
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Users\ContainerUser\.dotnet\tools"
+USER ContainerUser
 
 # Pre-pre dotnet
 RUN dotnet --info
 RUN dotnet tool install -g Cake.Tool --version 0.30.0
 RUN dotnet tool list -g
-WORKDIR \build
+WORKDIR /build
 COPY .\ .
 RUN dotnet cake

--- a/Windows.Vulnerable.Dockerfile
+++ b/Windows.Vulnerable.Dockerfile
@@ -1,5 +1,9 @@
 FROM microsoft/dotnet:2.1-sdk
 
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Users\ContainerUser\.dotnet\tools"
+USER ContainerUser
+
 # copy project
 WORKDIR VulnerableApp
 COPY SampleProjects/VulnerableApp/VulnerableApp.csproj ./

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 image:
-- Visual Studio 2017
+- Windows Server 2019
 
 build_script:
   - docker build -f Windows.Dockerfile .

--- a/gitprune.sh
+++ b/gitprune.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# deletes branches merged to master at the remote (origin)
+
+git fetch --prune
+branch=$(git rev-parse --abbrev-ref HEAD)
+git branch -r --merged | grep origin | grep -v '>' | grep -v master | grep -v $branch | awk '{split($0,a,"origin/"); print a[2]}' | xargs git push origin --delete
+git branch --merged | grep -v master | grep -v $branch | xargs git branch -d
+git remote prune origin


### PR DESCRIPTION
1) Use the new Windows Server 2019 image [on pr request by AppVeyor help](https://help.appveyor.com/discussions/problems/23601-new-docker-windows-images-not-able-to-pull-with-current-windows-host#comment_47352899).

2) Add .NET Core global tool path to PATH.

3) Other: Adds script to easily delete merged branches.