### PR TITLE
Add sln file and specific file location support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ $ dotnet retire
 
 Additional options:
 
-  - `loglevel=Trace|Debug|Information|Warning|Error|Critical` (default:`Information`)
-
-  - `rooturl=<url>` to feed> (default:[https://raw.githubusercontent.com/RetireNet/Packages/master/index.json](https://raw.githubusercontent.com/RetireNet/Packages/master/index.json))
+- `[--loglevel] {Trace|Debug|Information|Warning|Error|Critical}` (default: `Information`)
+- `[--rooturl] <URL_TO_FEED>` (default: <https://raw.githubusercontent.com/RetireNet/Packages/master/index.json>)
+- `[-p|--path] <PATH>` to *.csproj* or *.sln* file (default: current directory)
 
 Sample:
 
 ```
-$ dotnet retire loglevel=debug
+$ dotnet retire --loglevel debug
 ```
 
 #### Sample output:

--- a/src/RetireNet.Packages.Tool/Host.cs
+++ b/src/RetireNet.Packages.Tool/Host.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -15,26 +16,35 @@ namespace RetireNet.Packages.Tool
         {
             var builder = new ConfigurationBuilder();
             builder.AddJsonFile("appsettings.json");
-            builder.AddCommandLine(args);
+            builder.AddCommandLine(args, new Dictionary<string, string>
+            {
+                { "-p", "path" },
+                { "--path", "path" },
+            });
             var config = builder.Build();
 
 
+            var path = config.GetValue<string>("path");
             var rootUrlFromConfig = config.GetValue<Uri>("RootUrl");
             var logLevel = config.GetValue<LogLevel>("LogLevel");
 
             _services = new ServiceCollection()
-                .AddLogging(c => c.AddConsole().AddDebug().SetMinimumLevel(logLevel))
-                .AddOptions()
-                .Configure<RetireServiceOptions>(o => o.RootUrl = rootUrlFromConfig)
-                .AddTransient<RetireApiClient>()
-                .AddTransient<IFileService,FileService>()
-                .AddTransient<DotNetExeWrapper>()
-                .AddTransient<DotNetRunner>()
-                .AddTransient<DotNetRestorer>()
-                .AddTransient<IAssetsFileParser, NugetProjectModelAssetsFileParser>()
-                .AddTransient<UsagesFinder>()
-                .AddTransient<RetireLogger>()
-                .BuildServiceProvider();
+                    .AddLogging(c => c.AddConsole().AddDebug().SetMinimumLevel(logLevel))
+                    .AddOptions()
+                    .Configure<RetireServiceOptions>(o =>
+                    {
+                        o.RootUrl = rootUrlFromConfig;
+                        o.Path = path;
+                    })
+                    .AddTransient<RetireApiClient>()
+                    .AddTransient<IFileService, FileService>()
+                    .AddTransient<DotNetExeWrapper>()
+                    .AddTransient<DotNetRunner>()
+                    .AddTransient<DotNetRestorer>()
+                    .AddTransient<IAssetsFileParser, NugetProjectModelAssetsFileParser>()
+                    .AddTransient<UsagesFinder>()
+                    .AddTransient<RetireLogger>()
+                    .BuildServiceProvider();
 
             return this;
         }

--- a/src/RetireNet.Packages.Tool/Services/FileService.cs
+++ b/src/RetireNet.Packages.Tool/Services/FileService.cs
@@ -31,7 +31,9 @@ namespace RetireNet.Packages.Tool.Services
                 var solutionFile = Directory.EnumerateFiles(GetCurrentDirectory(), "*.sln", SearchOption.TopDirectoryOnly).FirstOrDefault();
                 if (solutionFile != null)
                 {
-                    foreach (var assetsFile in GetAssetFilesFromSolution(solutionFile))
+                    var assetsFiles = GetAssetFilesFromSolution(solutionFile);
+                    _logger.LogDebug($"Found solution {Path.GetFileName(solutionFile)} with {assetsFiles.Count()} projects in it".Green());
+                    foreach (var assetsFile in assetsFiles)
                     {
                         _logger.LogDebug($"Found {_assetsFileName} file at '{assetsFile}'".Green());
                         lockfiles.Add(LockFileUtilities.GetLockFile(assetsFile, new NuGetLogger(_logger)));

--- a/src/RetireNet.Packages.Tool/Services/FileService.cs
+++ b/src/RetireNet.Packages.Tool/Services/FileService.cs
@@ -32,7 +32,7 @@ namespace RetireNet.Packages.Tool.Services
                 if (solutionFile != null)
                 {
                     var assetsFiles = GetAssetFilesFromSolution(solutionFile);
-                    var plural = assetsFiles.Count() > 0 ? "s" : string.Empty;
+                    var plural = assetsFiles.Count() > 1 ? "s" : string.Empty;
                     _logger.LogDebug($"Found solution {Path.GetFileName(solutionFile)} with {assetsFiles.Count()} project{plural} in it".Green());
                     foreach (var assetsFile in assetsFiles)
                     {

--- a/src/RetireNet.Packages.Tool/Services/FileService.cs
+++ b/src/RetireNet.Packages.Tool/Services/FileService.cs
@@ -32,7 +32,8 @@ namespace RetireNet.Packages.Tool.Services
                 if (solutionFile != null)
                 {
                     var assetsFiles = GetAssetFilesFromSolution(solutionFile);
-                    _logger.LogDebug($"Found solution {Path.GetFileName(solutionFile)} with {assetsFiles.Count()} projects in it".Green());
+                    var plural = assetsFiles.Count() > 0 ? "s" : string.Empty;
+                    _logger.LogDebug($"Found solution {Path.GetFileName(solutionFile)} with {assetsFiles.Count()} project{plural} in it".Green());
                     foreach (var assetsFile in assetsFiles)
                     {
                         _logger.LogDebug($"Found {_assetsFileName} file at '{assetsFile}'".Green());

--- a/src/RetireNet.Packages.Tool/Services/IAssetsFileParser.cs
+++ b/src/RetireNet.Packages.Tool/Services/IAssetsFileParser.cs
@@ -1,10 +1,11 @@
 using System.Collections.Generic;
+using NuGet.ProjectModel;
 using RetireNet.Packages.Tool.Models;
 
 namespace RetireNet.Packages.Tool.Services
 {
     public interface IAssetsFileParser
     {
-        IEnumerable<NugetReference> GetNugetReferences();
+        IEnumerable<NugetReference> GetNugetReferences(LockFile lockFile);
     }
 }

--- a/src/RetireNet.Packages.Tool/Services/IFileService.cs
+++ b/src/RetireNet.Packages.Tool/Services/IFileService.cs
@@ -1,11 +1,13 @@
 
+using System.Collections.Generic;
 using NuGet.ProjectModel;
 
 namespace RetireNet.Packages.Tool.Services
 {
     public interface IFileService
     {
-        LockFile ReadLockFile();
+        IEnumerable<LockFile> ReadLockFiles();
+
         string GetCurrentDirectory();
     }
 }

--- a/src/RetireNet.Packages.Tool/Services/NugetProjectModelAssetsFileParser.cs
+++ b/src/RetireNet.Packages.Tool/Services/NugetProjectModelAssetsFileParser.cs
@@ -17,9 +17,9 @@ namespace RetireNet.Packages.Tool.Services
         {
             foreach (var lockfile in _fileService.ReadLockFiles())
             {
-                foreach (var x in lockfile.Targets)
+                foreach (var target in lockfile.Targets)
                 {
-                    foreach (var lib in x.Libraries)
+                    foreach (var lib in target.Libraries)
                     {
                         yield return new NugetReference
                         {

--- a/src/RetireNet.Packages.Tool/Services/NugetProjectModelAssetsFileParser.cs
+++ b/src/RetireNet.Packages.Tool/Services/NugetProjectModelAssetsFileParser.cs
@@ -15,23 +15,24 @@ namespace RetireNet.Packages.Tool.Services
 
         public IEnumerable<NugetReference> GetNugetReferences()
         {
-            var lockfile = _fileService.ReadLockFile();
-
-            foreach (var x in lockfile.Targets)
+            foreach (var lockfile in _fileService.ReadLockFiles())
             {
-                foreach (var lib in x.Libraries)
+                foreach (var x in lockfile.Targets)
                 {
-                    yield return new NugetReference
+                    foreach (var lib in x.Libraries)
                     {
-                        Id = lib.Name,
-                        Version = lib.Version.OriginalVersion,
-                        Dependencies = lib.Dependencies.Select(d =>
-                            new NugetReference
-                            {
-                                Id = d.Id,
-                                Version = d.VersionRange.MinVersion.OriginalVersion
-                            }).ToList()
-                    };
+                        yield return new NugetReference
+                        {
+                            Id = lib.Name,
+                            Version = lib.Version.OriginalVersion,
+                            Dependencies = lib.Dependencies.Select(d =>
+                                new NugetReference
+                                {
+                                    Id = d.Id,
+                                    Version = d.VersionRange.MinVersion.OriginalVersion
+                                }).ToList()
+                        };
+                    }
                 }
             }
         }

--- a/src/RetireNet.Packages.Tool/Services/NugetProjectModelAssetsFileParser.cs
+++ b/src/RetireNet.Packages.Tool/Services/NugetProjectModelAssetsFileParser.cs
@@ -1,38 +1,29 @@
 using System.Collections.Generic;
 using System.Linq;
+using NuGet.ProjectModel;
 using RetireNet.Packages.Tool.Models;
 
 namespace RetireNet.Packages.Tool.Services
 {
     public class NugetProjectModelAssetsFileParser : IAssetsFileParser
     {
-        private readonly IFileService _fileService;
-
-        public NugetProjectModelAssetsFileParser(IFileService fileService)
+        public IEnumerable<NugetReference> GetNugetReferences(LockFile lockFile)
         {
-            _fileService = fileService;
-        }
-
-        public IEnumerable<NugetReference> GetNugetReferences()
-        {
-            foreach (var lockfile in _fileService.ReadLockFiles())
+            foreach (var target in lockFile.Targets)
             {
-                foreach (var target in lockfile.Targets)
+                foreach (var lib in target.Libraries)
                 {
-                    foreach (var lib in target.Libraries)
+                    yield return new NugetReference
                     {
-                        yield return new NugetReference
-                        {
-                            Id = lib.Name,
-                            Version = lib.Version.OriginalVersion,
-                            Dependencies = lib.Dependencies.Select(d =>
-                                new NugetReference
-                                {
-                                    Id = d.Id,
-                                    Version = d.VersionRange.MinVersion.OriginalVersion
-                                }).ToList()
-                        };
-                    }
+                        Id = lib.Name,
+                        Version = lib.Version.OriginalVersion,
+                        Dependencies = lib.Dependencies.Select(d =>
+                            new NugetReference
+                            {
+                                Id = d.Id,
+                                Version = d.VersionRange.MinVersion.OriginalVersion
+                            }).ToList()
+                    };
                 }
             }
         }

--- a/src/RetireNet.Packages.Tool/Services/RetireServiceOptions.cs
+++ b/src/RetireNet.Packages.Tool/Services/RetireServiceOptions.cs
@@ -6,5 +6,7 @@ namespace RetireNet.Packages.Tool.Services
     {
 
         public Uri RootUrl { get; set; }
+
+        public string Path { get; set; }
     }
 }

--- a/test/RetireNet.Packages.Tool.Tests/MockFileService.cs
+++ b/test/RetireNet.Packages.Tool.Tests/MockFileService.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using Microsoft.Extensions.Options;
 using RetireNet.Packages.Tool.Services;
 
 namespace DotNetRetire.Tests
@@ -7,7 +8,7 @@ namespace DotNetRetire.Tests
     {
         private readonly string _prefix;
 
-        public MockFileService(string prefix) : base(new NoOpLogger())
+        public MockFileService(string prefix) : base(new NoOpLogger(), Options.Create(new RetireServiceOptions()))
         {
             _prefix = prefix;
         }

--- a/test/RetireNet.Packages.Tool.Tests/NugetReferenceServiceTests.cs
+++ b/test/RetireNet.Packages.Tool.Tests/NugetReferenceServiceTests.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using NuGet.ProjectModel;
 using RetireNet.Packages.Tool.Services;
 using Xunit;
 
@@ -7,17 +6,13 @@ namespace DotNetRetire.Tests
 {
     public class AssetServiceTests
     {
-        public NugetProjectModelAssetsFileParser NugetReferenceService(string prefix)
-        {
-            var mock = new MockFileService(prefix);
-
-            return new NugetProjectModelAssetsFileParser(mock);
-        }
+        private readonly IAssetsFileParser _assetsFileParser = new NugetProjectModelAssetsFileParser();
 
         [Fact]
         public void GetDirectReferencesWithSingleDependency()
         {
-            var references = NugetReferenceService("SingleTarget").GetNugetReferences();
+            var lockFile = new MockFileService("SingleTarget").ReadLockFiles().FirstOrDefault();
+            var references = _assetsFileParser.GetNugetReferences(lockFile);
 
             Assert.Single(references);
             Assert.Equal("Libuv", references.First().Id);
@@ -30,7 +25,8 @@ namespace DotNetRetire.Tests
         [Fact]
         public void GetDirectReferenceWithMultipleDependencies()
         {
-            var references = NugetReferenceService("SingleTarget-MultipleDependencies").GetNugetReferences();
+            var lockFile = new MockFileService("SingleTarget-MultipleDependencies").ReadLockFiles().FirstOrDefault();
+            var references = _assetsFileParser.GetNugetReferences(lockFile);
 
             Assert.Single(references);
             Assert.Equal("Newtonsoft.Json", references.First().Id);
@@ -46,7 +42,8 @@ namespace DotNetRetire.Tests
         [Fact]
         public void GetVulnerableDapperButWithManuallyUpdateSystemNetSecurity()
         {
-            var references = NugetReferenceService("SingleTarget.ManuallyFixedUpgrade").GetNugetReferences().ToArray();
+            var lockFile = new MockFileService("SingleTarget.ManuallyFixedUpgrade").ReadLockFiles().FirstOrDefault();
+            var references = _assetsFileParser.GetNugetReferences(lockFile).ToArray();
 
             Assert.Equal(3, references.Count());
 


### PR DESCRIPTION
Hi,

this PR fixes #46 and adds support for specific file locations on top.

- Add `-p` / `--path` cmd option support
- Add `Path` option property
- Add solution evaluation support

Examples

- `dotnet retire -p <path/to/project/or/sln>`
- `dotnet retire --path <path/to/project/or/sln>`