### PR TITLE
Return non-zero exit code on failures

### DIFF
--- a/Linux.Vulnerable.Dockerfile
+++ b/Linux.Vulnerable.Dockerfile
@@ -5,6 +5,7 @@ ENV PATH="/root/.dotnet/tools:${PATH}"
 
 
 WORKDIR /dotnet-retire
+COPY ./assert-cmd.sh ./
 COPY ./src/RetireNet.Packages.Tool ./
 RUN dotnet build
 RUN dotnet pack -o ../deploy /p:Version=999.0.0
@@ -13,18 +14,20 @@ RUN dotnet tool list -g
 
 WORKDIR /VulnerableApp
 COPY SampleProjects/VulnerableApp/VulnerableApp.csproj ./
-RUN dotnet retire --ignore-failures true --loglevel debug
-RUN dotnet retire --ignore-failures true
+RUN /dotnet-retire/assert-cmd.sh 3 "dotnet retire --loglevel debug"
+RUN /dotnet-retire/assert-cmd.sh 3 "dotnet retire"
+RUN /dotnet-retire/assert-cmd.sh 0 "dotnet retire --ignore-failures"
 
 WORKDIR /VulnerableRunTimeWebApp
 COPY SampleProjects/VulnerableRunTimeWebApp/VulnerableRunTimeWebApp.csproj ./
-RUN dotnet retire --ignore-failures true --loglevel debug
-RUN dotnet retire --ignore-failures true
+RUN /dotnet-retire/assert-cmd.sh 3 "dotnet retire --loglevel debug"
+RUN /dotnet-retire/assert-cmd.sh 3 "dotnet retire"
+RUN /dotnet-retire/assert-cmd.sh 0 "dotnet retire --ignore-failures"
 
 WORKDIR /VulnerableSolution
 COPY SampleProjects/VulnerableSolution.sln ./VulnerableSolution.sln
 COPY SampleProjects/VulnerableApp/VulnerableApp.csproj ./VulnerableApp/VulnerableApp.csproj
 COPY SampleProjects/VulnerableConsoleApp/VulnerableConsoleApp.csproj ./VulnerableConsoleApp/VulnerableConsoleApp.csproj
-RUN dotnet retire --ignore-failures true --loglevel debug
-RUN dotnet retire --ignore-failures true
-
+RUN /dotnet-retire/assert-cmd.sh 3 "dotnet retire --loglevel debug"
+RUN /dotnet-retire/assert-cmd.sh 3 "dotnet retire"
+RUN /dotnet-retire/assert-cmd.sh 0 "dotnet retire --ignore-failures"

--- a/Linux.Vulnerable.Dockerfile
+++ b/Linux.Vulnerable.Dockerfile
@@ -6,6 +6,7 @@ ENV PATH="/root/.dotnet/tools:${PATH}"
 
 WORKDIR /dotnet-retire
 COPY ./assert-cmd.sh ./
+RUN chmod +x entrypoint.sh
 COPY ./src/RetireNet.Packages.Tool ./
 RUN dotnet build
 RUN dotnet pack -o ../deploy /p:Version=999.0.0

--- a/Linux.Vulnerable.Dockerfile
+++ b/Linux.Vulnerable.Dockerfile
@@ -18,12 +18,12 @@ ENV PATH="/root/.dotnet/tools:${PATH}"
 
 RUN dotnet tool list -g
 
-RUN dotnet retire loglevel=debug
-RUN dotnet retire
+RUN dotnet retire --ignore-failures true --loglevel debug
+RUN dotnet retire --ignore-failures true
 
 WORKDIR /VulnerableSolution
 COPY SampleProjects/VulnerableSolution.sln ./VulnerableSolution.sln
 COPY SampleProjects/VulnerableApp/VulnerableApp.csproj ./VulnerableApp/VulnerableApp.csproj
 COPY SampleProjects/VulnerableConsoleApp/VulnerableConsoleApp.csproj ./VulnerableConsoleApp/VulnerableConsoleApp.csproj
 
-RUN dotnet retire
+RUN dotnet retire --ignore-failures true

--- a/Linux.Vulnerable.Dockerfile
+++ b/Linux.Vulnerable.Dockerfile
@@ -6,7 +6,7 @@ ENV PATH="/root/.dotnet/tools:${PATH}"
 
 WORKDIR /dotnet-retire
 COPY ./assert-cmd.sh ./
-RUN chmod +x entrypoint.sh
+RUN chmod +x assert-cmd.sh
 COPY ./src/RetireNet.Packages.Tool ./
 RUN dotnet build
 RUN dotnet pack -o ../deploy /p:Version=999.0.0
@@ -15,13 +15,13 @@ RUN dotnet tool list -g
 
 WORKDIR /VulnerableApp
 COPY SampleProjects/VulnerableApp/VulnerableApp.csproj ./
-RUN /dotnet-retire/assert-cmd.sh 3 "dotnet retire --loglevel debug"
+RUN /dotnet-retire/assert-cmd.sh 3 "dotnet retire --loglevel=debug"
 RUN /dotnet-retire/assert-cmd.sh 3 "dotnet retire"
 RUN /dotnet-retire/assert-cmd.sh 0 "dotnet retire --ignore-failures"
 
 WORKDIR /VulnerableRunTimeWebApp
 COPY SampleProjects/VulnerableRunTimeWebApp/VulnerableRunTimeWebApp.csproj ./
-RUN /dotnet-retire/assert-cmd.sh 3 "dotnet retire --loglevel debug"
+RUN /dotnet-retire/assert-cmd.sh 3 "dotnet retire --loglevel=debug"
 RUN /dotnet-retire/assert-cmd.sh 3 "dotnet retire"
 RUN /dotnet-retire/assert-cmd.sh 0 "dotnet retire --ignore-failures"
 
@@ -29,6 +29,6 @@ WORKDIR /VulnerableSolution
 COPY SampleProjects/VulnerableSolution.sln ./VulnerableSolution.sln
 COPY SampleProjects/VulnerableApp/VulnerableApp.csproj ./VulnerableApp/VulnerableApp.csproj
 COPY SampleProjects/VulnerableConsoleApp/VulnerableConsoleApp.csproj ./VulnerableConsoleApp/VulnerableConsoleApp.csproj
-RUN /dotnet-retire/assert-cmd.sh 3 "dotnet retire --loglevel debug"
+RUN /dotnet-retire/assert-cmd.sh 3 "dotnet retire --loglevel=debug"
 RUN /dotnet-retire/assert-cmd.sh 3 "dotnet retire"
 RUN /dotnet-retire/assert-cmd.sh 0 "dotnet retire --ignore-failures"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Additional options:
 
 - `[--loglevel] {Trace|Debug|Information|Warning|Error|Critical}` (default: `Information`)
 - `[--rooturl] <URL_TO_FEED>` (default: <https://raw.githubusercontent.com/RetireNet/Packages/master/index.json>)
+- `[--ignore-failures]` to always return a zero exit code (default: `false`)
 - `[-p|--path] <PATH>` to *.csproj* or *.sln* file (default: current directory)
 
 Sample:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Additional options:
 
 - `[--loglevel] {Trace|Debug|Information|Warning|Error|Critical}` (default: `Information`)
 - `[--rooturl] <URL_TO_FEED>` (default: <https://raw.githubusercontent.com/RetireNet/Packages/master/index.json>)
-- `[--ignore-failures]` to always return a zero exit code (default: `false`)
+- `[--ignore-failures] {true|false}` to always return a zero exit code (default: `false`)
 - `[-p|--path] <PATH>` to *.csproj* or *.sln* file (default: current directory)
 
 Sample:

--- a/Windows.Vulnerable.Dockerfile
+++ b/Windows.Vulnerable.Dockerfile
@@ -5,6 +5,7 @@ RUN setx /M PATH "%PATH%;C:\Users\ContainerUser\.dotnet\tools"
 USER ContainerUser
 
 WORKDIR /dotnet-retire
+COPY ./assert-cmd.sh ./
 COPY ./src/RetireNet.Packages.Tool ./
 RUN dotnet build
 RUN dotnet pack -o ../deploy /p:Version=999.0.0
@@ -13,19 +14,20 @@ RUN dotnet tool list -g
 
 WORKDIR /VulnerableApp
 COPY SampleProjects/VulnerableApp/VulnerableApp.csproj ./
-RUN dotnet retire --ignore-failures true --loglevel debug
-RUN dotnet retire --ignore-failures true
+RUN /dotnet-retire/assert-cmd.sh 3 "dotnet retire --loglevel debug"
+RUN /dotnet-retire/assert-cmd.sh 3 "dotnet retire"
+RUN /dotnet-retire/assert-cmd.sh 0 "dotnet retire --ignore-failures"
 
 WORKDIR /VulnerableRunTimeWebApp
 COPY SampleProjects/VulnerableRunTimeWebApp/VulnerableRunTimeWebApp.csproj ./
-RUN dotnet retire --ignore-failures true --loglevel debug
-RUN dotnet retire --ignore-failures true
+RUN /dotnet-retire/assert-cmd.sh 3 "dotnet retire --loglevel debug"
+RUN /dotnet-retire/assert-cmd.sh 3 "dotnet retire"
+RUN /dotnet-retire/assert-cmd.sh 0 "dotnet retire --ignore-failures"
 
 WORKDIR /VulnerableSolution
 COPY SampleProjects/VulnerableSolution.sln ./VulnerableSolution.sln
 COPY SampleProjects/VulnerableApp/VulnerableApp.csproj ./VulnerableApp/VulnerableApp.csproj
 COPY SampleProjects/VulnerableConsoleApp/VulnerableConsoleApp.csproj ./VulnerableConsoleApp/VulnerableConsoleApp.csproj
-RUN dotnet retire --ignore-failures true --loglevel debug
-RUN dotnet retire --ignore-failures true
-
-
+RUN /dotnet-retire/assert-cmd.sh 3 "dotnet retire --loglevel debug"
+RUN /dotnet-retire/assert-cmd.sh 3 "dotnet retire"
+RUN /dotnet-retire/assert-cmd.sh 0 "dotnet retire --ignore-failures"

--- a/Windows.Vulnerable.Dockerfile
+++ b/Windows.Vulnerable.Dockerfile
@@ -21,13 +21,13 @@ RUN dotnet tool install -g dotnet-retire --add-source ../deploy --version=999.0.
 
 RUN dotnet tool list -g
 
-RUN dotnet retire loglevel=debug
-RUN dotnet retire
+RUN dotnet retire --ignore-failures true --loglevel debug
+RUN dotnet retire --ignore-failures true
 
 WORKDIR /VulnerableSolution
 COPY SampleProjects/VulnerableSolution.sln ./VulnerableSolution.sln
 COPY SampleProjects/VulnerableApp/VulnerableApp.csproj ./VulnerableApp/VulnerableApp.csproj
 COPY SampleProjects/VulnerableConsoleApp/VulnerableConsoleApp.csproj ./VulnerableConsoleApp/VulnerableConsoleApp.csproj
 
-RUN dotnet retire loglevel=debug
+RUN dotnet retire --ignore-failures true --loglevel debug
 

--- a/Windows.Vulnerable.Dockerfile
+++ b/Windows.Vulnerable.Dockerfile
@@ -1,5 +1,6 @@
 FROM microsoft/dotnet:2.1-sdk
 
+
 USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;C:\Users\ContainerUser\.dotnet\tools"
 USER ContainerUser
@@ -15,20 +16,20 @@ RUN dotnet tool list -g
 
 WORKDIR /VulnerableApp
 COPY SampleProjects/VulnerableApp/VulnerableApp.csproj ./
-RUN /dotnet-retire/assert-cmd.bat 3 "dotnet-retire" "--loglevel debug"
+RUN /dotnet-retire/assert-cmd.bat 3 "dotnet-retire" "--loglevel=debug"
 RUN /dotnet-retire/assert-cmd.bat 3 "dotnet-retire"
 RUN /dotnet-retire/assert-cmd.bat 0 "dotnet-retire" "--ignore-failures"
 
 WORKDIR /VulnerableRunTimeWebApp
 COPY SampleProjects/VulnerableRunTimeWebApp/VulnerableRunTimeWebApp.csproj ./
-RUN /dotnet-retire/assert-cmd.bat 3 "dotnet-retire --loglevel debug"
+RUN /dotnet-retire/assert-cmd.bat 3 "dotnet-retire" "--loglevel=debug"
 RUN /dotnet-retire/assert-cmd.bat 3 "dotnet-retire"
-RUN /dotnet-retire/assert-cmd.bat 0 "dotnet-retire --ignore-failures"
+RUN /dotnet-retire/assert-cmd.bat 0 "dotnet-retire" "--ignore-failures"
 
 WORKDIR /VulnerableSolution
 COPY SampleProjects/VulnerableSolution.sln ./VulnerableSolution.sln
 COPY SampleProjects/VulnerableApp/VulnerableApp.csproj ./VulnerableApp/VulnerableApp.csproj
 COPY SampleProjects/VulnerableConsoleApp/VulnerableConsoleApp.csproj ./VulnerableConsoleApp/VulnerableConsoleApp.csproj
-RUN /dotnet-retire/assert-cmd.bat 3 "dotnet-retire" "--loglevel debug"
+RUN /dotnet-retire/assert-cmd.bat 3 "dotnet-retire" "--loglevel=debug"
 RUN /dotnet-retire/assert-cmd.bat 3 "dotnet-retire"
 RUN /dotnet-retire/assert-cmd.bat 0 "dotnet-retire" "--ignore-failures"

--- a/Windows.Vulnerable.Dockerfile
+++ b/Windows.Vulnerable.Dockerfile
@@ -5,7 +5,8 @@ RUN setx /M PATH "%PATH%;C:\Users\ContainerUser\.dotnet\tools"
 USER ContainerUser
 
 WORKDIR /dotnet-retire
-COPY ./assert-cmd.sh ./
+COPY ./assert-cmd.bat ./
+
 COPY ./src/RetireNet.Packages.Tool ./
 RUN dotnet build
 RUN dotnet pack -o ../deploy /p:Version=999.0.0
@@ -14,20 +15,20 @@ RUN dotnet tool list -g
 
 WORKDIR /VulnerableApp
 COPY SampleProjects/VulnerableApp/VulnerableApp.csproj ./
-RUN /dotnet-retire/assert-cmd.sh 3 "dotnet retire --loglevel debug"
-RUN /dotnet-retire/assert-cmd.sh 3 "dotnet retire"
-RUN /dotnet-retire/assert-cmd.sh 0 "dotnet retire --ignore-failures"
+RUN /dotnet-retire/assert-cmd.bat 3 "dotnet-retire" "--loglevel debug"
+RUN /dotnet-retire/assert-cmd.bat 3 "dotnet-retire"
+RUN /dotnet-retire/assert-cmd.bat 0 "dotnet-retire" "--ignore-failures"
 
 WORKDIR /VulnerableRunTimeWebApp
 COPY SampleProjects/VulnerableRunTimeWebApp/VulnerableRunTimeWebApp.csproj ./
-RUN /dotnet-retire/assert-cmd.sh 3 "dotnet retire --loglevel debug"
-RUN /dotnet-retire/assert-cmd.sh 3 "dotnet retire"
-RUN /dotnet-retire/assert-cmd.sh 0 "dotnet retire --ignore-failures"
+RUN /dotnet-retire/assert-cmd.bat 3 "dotnet-retire --loglevel debug"
+RUN /dotnet-retire/assert-cmd.bat 3 "dotnet-retire"
+RUN /dotnet-retire/assert-cmd.bat 0 "dotnet-retire --ignore-failures"
 
 WORKDIR /VulnerableSolution
 COPY SampleProjects/VulnerableSolution.sln ./VulnerableSolution.sln
 COPY SampleProjects/VulnerableApp/VulnerableApp.csproj ./VulnerableApp/VulnerableApp.csproj
 COPY SampleProjects/VulnerableConsoleApp/VulnerableConsoleApp.csproj ./VulnerableConsoleApp/VulnerableConsoleApp.csproj
-RUN /dotnet-retire/assert-cmd.sh 3 "dotnet retire --loglevel debug"
-RUN /dotnet-retire/assert-cmd.sh 3 "dotnet retire"
-RUN /dotnet-retire/assert-cmd.sh 0 "dotnet retire --ignore-failures"
+RUN /dotnet-retire/assert-cmd.bat 3 "dotnet-retire" "--loglevel debug"
+RUN /dotnet-retire/assert-cmd.bat 3 "dotnet-retire"
+RUN /dotnet-retire/assert-cmd.bat 0 "dotnet-retire" "--ignore-failures"

--- a/assert-cmd.bat
+++ b/assert-cmd.bat
@@ -1,0 +1,13 @@
+@echo off
+CD /D %~dp0
+
+echo "### AssertCMD - Executing command '%2 %3'"
+%2 %3
+
+if %ERRORLEVEL% neq %1 (
+  echo "### AssertCMD - FAIL: Expected exit code %1 is not equal to %ERRORLEVEL%" 1>&2
+  exit 999
+)
+
+echo "### AssertCMD - PASSED"
+exit 0

--- a/assert-cmd.sh
+++ b/assert-cmd.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+
 echo "### AssertCMD - Executing command '$2'"
 eval $2
 

--- a/assert-cmd.sh
+++ b/assert-cmd.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+echo "### AssertCMD - Executing command '$2'"
+eval $2
+
+if [ $? -ne $1 ]; then
+  echo "### AssertCMD - FAIL: Expected exit code $1 is not equal to $?" 1>&2
+  exit 999
+fi
+
+echo "### AssertCMD - PASSED"
+exit 0

--- a/src/RetireNet.Packages.Tool/Host.cs
+++ b/src/RetireNet.Packages.Tool/Host.cs
@@ -47,7 +47,7 @@ namespace RetireNet.Packages.Tool
                     .AddTransient<IAssetsFileParser, NugetProjectModelAssetsFileParser>()
                     .AddTransient<UsagesFinder>()
                     .AddTransient<RetireLogger>()
-                    .AddTransient<ExitCodeHandler>()
+                    .AddTransient<IExitCodeHandler, ExitCodeHandler>()
                     .BuildServiceProvider();
 
             return this;

--- a/src/RetireNet.Packages.Tool/Host.cs
+++ b/src/RetireNet.Packages.Tool/Host.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -20,11 +21,12 @@ namespace RetireNet.Packages.Tool
             {
                 { "-p", "path" },
                 { "--path", "path" },
+                { "--ignore-failures", "ignore-failures" }
             });
             var config = builder.Build();
 
-
             var path = config.GetValue<string>("path");
+            var alwaysExitWithZero = config.GetValue<bool?>("ignore-failures") ?? args.Any(x => x.Equals("--ignore-failures", StringComparison.OrdinalIgnoreCase));
             var rootUrlFromConfig = config.GetValue<Uri>("RootUrl");
             var logLevel = config.GetValue<LogLevel>("LogLevel");
 
@@ -35,6 +37,7 @@ namespace RetireNet.Packages.Tool
                     {
                         o.RootUrl = rootUrlFromConfig;
                         o.Path = path;
+                        o.AlwaysExitWithZero = alwaysExitWithZero;
                     })
                     .AddTransient<RetireApiClient>()
                     .AddTransient<IFileService, FileService>()
@@ -44,6 +47,7 @@ namespace RetireNet.Packages.Tool
                     .AddTransient<IAssetsFileParser, NugetProjectModelAssetsFileParser>()
                     .AddTransient<UsagesFinder>()
                     .AddTransient<RetireLogger>()
+                    .AddTransient<ExitCodeHandler>()
                     .BuildServiceProvider();
 
             return this;

--- a/src/RetireNet.Packages.Tool/Models/ExitCode.cs
+++ b/src/RetireNet.Packages.Tool/Models/ExitCode.cs
@@ -1,0 +1,8 @@
+﻿namespace RetireNet.Packages.Tool.Models
+{
+    public static class ExitCode
+    {
+        public const int FILE_NOT_FOUND = 0x2;
+        public const int FOUND_VULNERABILITIES = 0x3;
+    }
+}

--- a/src/RetireNet.Packages.Tool/Services/ExitCodeHandler.cs
+++ b/src/RetireNet.Packages.Tool/Services/ExitCodeHandler.cs
@@ -16,12 +16,12 @@ namespace RetireNet.Packages.Tool.Services
         {
             if (!_options.Value.AlwaysExitWithZero)
             {
-                if (exitImmediately)
-                {
-                    Environment.Exit(exitCode);
-                }
-
                 Environment.ExitCode = exitCode;
+            }
+
+            if (exitImmediately)
+            {
+                Environment.Exit(Environment.ExitCode);
             }
         }
     }

--- a/src/RetireNet.Packages.Tool/Services/ExitCodeHandler.cs
+++ b/src/RetireNet.Packages.Tool/Services/ExitCodeHandler.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace RetireNet.Packages.Tool.Services
 {
-    public class ExitCodeHandler
+    public class ExitCodeHandler : IExitCodeHandler
     {
         private readonly IOptions<RetireServiceOptions> _options;
 

--- a/src/RetireNet.Packages.Tool/Services/ExitCodeHandler.cs
+++ b/src/RetireNet.Packages.Tool/Services/ExitCodeHandler.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.Extensions.Options;
+using System;
+
+namespace RetireNet.Packages.Tool.Services
+{
+    public class ExitCodeHandler
+    {
+        private readonly IOptions<RetireServiceOptions> _options;
+
+        public ExitCodeHandler(IOptions<RetireServiceOptions> options)
+        {
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+        }
+
+        public void HandleExitCode(int exitCode, bool exitImmediately = false)
+        {
+            if (!_options.Value.AlwaysExitWithZero)
+            {
+                if (exitImmediately)
+                {
+                    Environment.Exit(exitCode);
+                }
+
+                Environment.ExitCode = exitCode;
+            }
+        }
+    }
+}

--- a/src/RetireNet.Packages.Tool/Services/IExitCodeHandler.cs
+++ b/src/RetireNet.Packages.Tool/Services/IExitCodeHandler.cs
@@ -1,0 +1,7 @@
+﻿namespace RetireNet.Packages.Tool.Services
+{
+    public interface IExitCodeHandler
+    {
+        void HandleExitCode(int exitCode, bool exitImmediately = false);
+    }
+}

--- a/src/RetireNet.Packages.Tool/Services/RetireLogger.cs
+++ b/src/RetireNet.Packages.Tool/Services/RetireLogger.cs
@@ -16,10 +16,10 @@ namespace RetireNet.Packages.Tool.Services
         private readonly UsagesFinder _usageFinder;
         private readonly DotNetRestorer _restorer;
         private readonly IFileService _fileService;
-        private readonly ExitCodeHandler _exitCodeHandler;
+        private readonly IExitCodeHandler _exitCodeHandler;
 
         public RetireLogger(ILogger<RetireLogger> logger, RetireApiClient retireApiClient, IAssetsFileParser nugetreferenceservice,
-            UsagesFinder usageFinder, DotNetRestorer restorer, IFileService fileService, ExitCodeHandler exitCodeHandler)
+            UsagesFinder usageFinder, DotNetRestorer restorer, IFileService fileService, IExitCodeHandler exitCodeHandler)
         {
             _logger = logger;
             _retireApiClient = retireApiClient;

--- a/src/RetireNet.Packages.Tool/Services/RetireLogger.cs
+++ b/src/RetireNet.Packages.Tool/Services/RetireLogger.cs
@@ -56,16 +56,14 @@ namespace RetireNet.Packages.Tool.Services
                 _logger.LogDebug("`dotnet restore exitcode:`" + status.ExitCode);
 
                 _logger.LogError("Failed to `dotnet restore`. Is the current dir missing a csproj?");
-                _exitCodeHandler.HandleExitCode(status.ExitCode);
-                return;
+                _exitCodeHandler.HandleExitCode(status.ExitCode, true);
             }
 
             var lockFiles = _fileService.ReadLockFiles();
             if (!lockFiles.Any())
             {
                 _logger.LogError("No assets found. Are you running the tool from a folder missing a csproj or sln?");
-                _exitCodeHandler.HandleExitCode(ExitCode.FILE_NOT_FOUND);
-                return;
+                _exitCodeHandler.HandleExitCode(ExitCode.FILE_NOT_FOUND, true);
             }
 
             var foundVulnerabilities = false;
@@ -73,7 +71,7 @@ namespace RetireNet.Packages.Tool.Services
             {
                 _logger.LogInformation($"Analyzing '{lockFile.PackageSpec.Name}'".Green());
 
-                List<NugetReference> nugetReferences;
+                List<NugetReference> nugetReferences = null;
                 try
                 {
                     nugetReferences = _nugetreferenceservice.GetNugetReferences(lockFile).ToList();
@@ -81,8 +79,7 @@ namespace RetireNet.Packages.Tool.Services
                 catch (NoAssetsFoundException ex)
                 {
                     _logger.LogError("No assets found. Are you running the tool from a folder missing a csproj?");
-                    _exitCodeHandler.HandleExitCode(ex.HResult);
-                    return;
+                    _exitCodeHandler.HandleExitCode(ex.HResult, true);
                 }
 
                 _logger.LogDebug($"Found in total {nugetReferences.Count} references of NuGets (direct & transient)");

--- a/src/RetireNet.Packages.Tool/Services/RetireServiceOptions.cs
+++ b/src/RetireNet.Packages.Tool/Services/RetireServiceOptions.cs
@@ -8,5 +8,7 @@ namespace RetireNet.Packages.Tool.Services
         public Uri RootUrl { get; set; }
 
         public string Path { get; set; }
+
+        public bool AlwaysExitWithZero { get; set; }
     }
 }


### PR DESCRIPTION
Hey,

this PR fixes #49 and always returns a non-zero exit code by default. Optionally there is an `--ignore-failures` opt-out argument option, which can be set to true to always return a zero exit code.

Examples

- Opt In (default): `dotnet retire --ignore-failures false`
- Opt out: `dotnet retire --ignore-failures true`

ToDos

- [x] Return non-zero exit codes by default
- [x] Add opt out option
- [x] Add documentation
- [x] Add tests
- [x] Check and fix possible docker build test errors